### PR TITLE
Optimize plotting speed and memory consumption

### DIFF
--- a/src/commands/plot.rs
+++ b/src/commands/plot.rs
@@ -127,7 +127,7 @@ pub async fn plot(
         );
 
         info!(
-            "Plotting throughput is {} mb/sec\n",
+            "Plotting throughput is {} MB/sec\n",
             ((piece_count as u64 * PIECE_SIZE as u64) / (1000 * 1000)) as f32
                 / (total_plot_time.as_secs_f32())
         );

--- a/src/commands/plot.rs
+++ b/src/commands/plot.rs
@@ -1,7 +1,7 @@
 use crate::plot::Plot;
-use crate::{crypto, utils, Piece, Salt, ENCODE_ROUNDS, PIECE_SIZE, PRIME_SIZE_BYTES};
-use async_std::task;
-use futures::channel::oneshot;
+use crate::{crypto, Piece, Salt, ENCODE_ROUNDS, PIECE_SIZE, PRIME_SIZE_BYTES};
+use futures::channel::{mpsc, oneshot};
+use futures::{SinkExt, StreamExt};
 use indicatif::ProgressBar;
 use log::{info, warn};
 use rayon::prelude::*;
@@ -9,7 +9,10 @@ use schnorrkel::Keypair;
 use spartan::Spartan;
 use std::fs;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Instant;
+
+const BATCH_SIZE: u64 = (16 * 1024 * 1204 / PIECE_SIZE) as u64;
 
 pub async fn plot(
     path: PathBuf,
@@ -30,36 +33,53 @@ pub async fn plot(
 
     let plot = Plot::open_or_create(&path.into()).await?;
     let public_key_hash = crypto::hash_public_key(&keypair.public);
-    let spartan: Spartan<PRIME_SIZE_BYTES, PIECE_SIZE> =
-        Spartan::<PRIME_SIZE_BYTES, PIECE_SIZE>::new(genesis_piece);
+    let spartan: Arc<Spartan<PRIME_SIZE_BYTES, PIECE_SIZE>> =
+        Arc::new(Spartan::<PRIME_SIZE_BYTES, PIECE_SIZE>::new(genesis_piece));
 
     if plot.is_empty().await {
-        let plotting_fut = utils::spawn_blocking({
+        let plotting_fut = {
             let plot = plot.clone();
 
-            move || {
-                let bar = ProgressBar::new(piece_count);
+            async move {
+                let (mut batch_sender, mut batch_receiver) = mpsc::channel(1);
 
-                (0..piece_count).into_par_iter().for_each(|index| {
-                    let encoding = spartan.encode(public_key_hash, index, ENCODE_ROUNDS);
+                std::thread::spawn(move || {
+                    let bar = ProgressBar::new(piece_count);
 
-                    task::spawn({
-                        let plot = plot.clone();
+                    for batch_start in (0..piece_count).step_by(BATCH_SIZE as usize) {
+                        let batch_end = (batch_start + BATCH_SIZE).min(piece_count);
+                        let encoded_batch: Vec<Piece> = (batch_start..batch_end)
+                            .into_par_iter()
+                            .map(|index| {
+                                let encoding =
+                                    spartan.encode(public_key_hash, index, ENCODE_ROUNDS);
 
-                        async move {
-                            let result = plot.write(encoding, index, salt).await;
+                                bar.inc(1);
 
-                            if let Err(error) = result {
-                                warn!("{}", error);
-                            }
+                                encoding
+                            })
+                            .collect();
+
+                        if futures::executor::block_on(
+                            batch_sender.send((batch_start, encoded_batch)),
+                        )
+                        .is_err()
+                        {
+                            return;
                         }
-                    });
-                    bar.inc(1);
-                });
+                    }
 
-                bar.finish();
+                    bar.finish();
+                });
+                while let Some((batch_start, encoded_batch)) = batch_receiver.next().await {
+                    let result = plot.write_many(encoded_batch, batch_start, salt).await;
+
+                    if let Err(error) = result {
+                        warn!("{}", error);
+                    }
+                }
             }
-        });
+        };
 
         let plot_time = Instant::now();
 

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -465,7 +465,7 @@ mod tests {
 
         let plot = Plot::open_or_create(&path).await.unwrap();
         assert_eq!(true, plot.is_empty().await);
-        plot.write(piece, index, salt).await.unwrap();
+        plot.write_many(vec![piece], index, salt).await.unwrap();
         assert_eq!(false, plot.is_empty().await);
         let extracted_piece = plot.read(index).await.unwrap();
 
@@ -492,74 +492,81 @@ mod tests {
         let salt: Salt = [1u8; 32];
 
         let plot = Plot::open_or_create(&path).await.unwrap();
-        for index in 0..1024 {
-            let piece = generate_random_piece();
-            plot.write(piece, index, salt).await.unwrap();
-        }
+
+        plot.write_many(
+            (0..1024_usize).map(|_| generate_random_piece()).collect(),
+            0,
+            salt,
+        )
+        .await
+        .unwrap();
 
         {
             let target = [0u8, 0, 0, 0, 0, 0, 0, 1];
             let solution_range =
                 u64::from_be_bytes([0u8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
-            let solutions = plot.find_by_range(target, solution_range).await.unwrap();
             // This is probabilistic, but should be fine most of the time
-            assert!(!solutions.is_empty());
+            let (solution, _) = plot
+                .find_by_range(target, solution_range)
+                .await
+                .unwrap()
+                .unwrap();
             // Wraps around
             let lower = u64::from_be_bytes(target).wrapping_sub(solution_range / 2);
             let upper = u64::from_be_bytes(target) + solution_range / 2;
-            for (solution, _) in solutions {
-                let solution = u64::from_be_bytes(solution);
-                assert!(
-                    solution >= lower || solution <= upper,
-                    "Solution {:?} must be over wrapped lower edge {:?} or under upper edge {:?}",
-                    solution.to_be_bytes(),
-                    lower.to_be_bytes(),
-                    upper.to_be_bytes(),
-                );
-            }
+            let solution = u64::from_be_bytes(solution);
+            assert!(
+                solution >= lower || solution <= upper,
+                "Solution {:?} must be over wrapped lower edge {:?} or under upper edge {:?}",
+                solution.to_be_bytes(),
+                lower.to_be_bytes(),
+                upper.to_be_bytes(),
+            );
         }
 
         {
             let target = [0xff_u8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe];
             let solution_range =
                 u64::from_be_bytes([0u8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
-            let solutions = plot.find_by_range(target, solution_range).await.unwrap();
             // This is probabilistic, but should be fine most of the time
-            assert!(!solutions.is_empty());
+            let (solution, _) = plot
+                .find_by_range(target, solution_range)
+                .await
+                .unwrap()
+                .unwrap();
             // Wraps around
             let lower = u64::from_be_bytes(target) - solution_range / 2;
             let upper = u64::from_be_bytes(target).wrapping_add(solution_range / 2);
-            for (solution, _) in solutions {
-                let solution = u64::from_be_bytes(solution);
-                assert!(
-                    solution >= lower || solution <= upper,
-                    "Solution {:?} must be over lower edge {:?} or under wrapped upper edge {:?}",
-                    solution.to_be_bytes(),
-                    lower.to_be_bytes(),
-                    upper.to_be_bytes(),
-                );
-            }
+            let solution = u64::from_be_bytes(solution);
+            assert!(
+                solution >= lower || solution <= upper,
+                "Solution {:?} must be over lower edge {:?} or under wrapped upper edge {:?}",
+                solution.to_be_bytes(),
+                lower.to_be_bytes(),
+                upper.to_be_bytes(),
+            );
         }
 
         {
             let target = [0xef_u8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff];
             let solution_range =
                 u64::from_be_bytes([0u8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
-            let solutions = plot.find_by_range(target, solution_range).await.unwrap();
             // This is probabilistic, but should be fine most of the time
-            assert!(!solutions.is_empty());
+            let (solution, _) = plot
+                .find_by_range(target, solution_range)
+                .await
+                .unwrap()
+                .unwrap();
             let lower = u64::from_be_bytes(target) - solution_range / 2;
             let upper = u64::from_be_bytes(target) + solution_range / 2;
-            for (solution, _) in solutions {
-                let solution = u64::from_be_bytes(solution);
-                assert!(
-                    solution >= lower && solution <= upper,
-                    "Solution {:?} must be over lower edge {:?} and under upper edge {:?}",
-                    solution.to_be_bytes(),
-                    lower.to_be_bytes(),
-                    upper.to_be_bytes(),
-                );
-            }
+            let solution = u64::from_be_bytes(solution);
+            assert!(
+                solution >= lower && solution <= upper,
+                "Solution {:?} must be over lower edge {:?} and under upper edge {:?}",
+                solution.to_be_bytes(),
+                lower.to_be_bytes(),
+                upper.to_be_bytes(),
+            );
         }
 
         drop(plot);


### PR DESCRIPTION
Writes plot data in blocks of 16M instead of piece by piece, waits for disk operations if encoding is much faster that disk writes